### PR TITLE
Set heading color to use $link-color variable

### DIFF
--- a/_sass/_agent.scss
+++ b/_sass/_agent.scss
@@ -24,7 +24,7 @@
 
 .agent-info h3 {
     margin-top: 0;
-    color: #521370;
+    color: $link-color;
 }
 
 .agent-emoji {


### PR DESCRIPTION
Replaced the hardcoded color value with the $link-color Sass variable to improve consistency and maintainability. This ensures easier updates and alignment with the site's color scheme.