### PR TITLE
Update reading time calculation in blog grid template

### DIFF
--- a/_includes/blog-grid.html
+++ b/_includes/blog-grid.html
@@ -19,7 +19,7 @@
                 <span class="blog-card__author">{{ post.author }}</span>
                 {% endif %}
                 {% if post.reading_time %}
-                <span class="blog-card__reading-time">{{ post.reading_time }} min read</span>
+                <span class="blog-card__reading-time">{{ post.content | reading_time }} min read</span>
                 {% endif %}
             </div>
             <p class="blog-card__excerpt">{{ post.excerpt | strip_html | truncatewords: 30 }}</p>


### PR DESCRIPTION
Replaced the use of the `post.reading_time` variable with a dynamically computed value using the `reading_time` filter. This ensures the reading time is accurately calculated based on the post's content.