### PR TITLE
Update blog grid date format and reading time display

### DIFF
--- a/_includes/blog-grid.html
+++ b/_includes/blog-grid.html
@@ -13,13 +13,20 @@
             </h2>
             <div class="blog-card__meta">
                 <time datetime="{{ post.date | date_to_xmlschema }}">
-                    {{ post.date | date: "%B %d, %Y" }}
+                    {{ post.date | date: "%d. %B %Y" }}
                 </time>
                 {% if post.author %}
                 <span class="blog-card__author">{{ post.author }}</span>
                 {% endif %}
                 {% if post.reading_time %}
-                <span class="blog-card__reading-time">{{ post.content | reading_time }} min read</span>
+                <span class="blog-card__reading-time">
+                    {% assign reading_time = post.content | reading_time | round %}
+                    {% if reading_time == 1 %}
+                      {{ reading_time }} Minute Lesezeit
+                    {% else %}
+                      {{ reading_time }} Minuten Lesezeit
+                    {% endif %}
+                </span>
                 {% endif %}
             </div>
             <p class="blog-card__excerpt">{{ post.excerpt | strip_html | truncatewords: 30 }}</p>


### PR DESCRIPTION
The date format has been changed to "DD. Month YYYY" and the reading time text is now displayed in German with singular/plural handling for "Minute/Minuten". This improves localization and readability for German-speaking users.