### PR TITLE
Fix: Add uppercase README.md for proper case convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# satwareai-mkdocs
+
+A documentation website for satware.ai built with MkDocs and the Material for MkDocs theme.
+
+## Overview
+
+This project contains the source files for the satware.ai documentation website. It uses MkDocs as the static site generator and the Material for MkDocs theme for styling and enhanced functionality.
+
+## Setup and Installation
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/satware-ag/satwareai-mkdocs.git
+   cd satwareai-mkdocs
+   ```
+
+
+2. Create and activate a virtual environment:
+
+   ```bash
+    python -m venv venv
+    source venv/bin/activate  # On Windows: venv\Scripts\activate
+    ```
+
+3. Install the dependencies:
+
+  ```bash
+    pip install -r requirements.txt
+  ```
+
+
+## Development
+
+To start the development server:
+
+
+```bash
+./dev.sh
+```
+
+Or manually:
+
+```bash
+mkdocs serve
+```
+
+
+This will start a local development server at [http://127.0.0.1:8000/](http://127.0.0.1:8000/) that automatically reloads when you make changes to the documentation.
+
+### SCSS Compilation
+
+The project uses SCSS for styling. To compile SCSS files to CSS:
+
+
+
+```bash
+python compile_scss.py
+```
+
+## Building the Site
+
+To build the static site:
+
+
+```bash
+mkdocs build
+```
+
+This will create a `site` directory with the built static site.
+
+
+## Theme Customization
+
+The site uses the Material for MkDocs theme with custom overrides located in the `docs/overrides` directory. Additional styling is provided through SCSS files in the `docs/stylesheets` directory.
+
+## Documentation
+
+For more information about MkDocs and the Material for MkDocs theme, refer to:
+
+- [MkDocs Documentation](https://www.mkdocs.org/getting-started/)
+- [Material for MkDocs Documentation](https://squidfunk.github.io/mkdocs-material/getting-started/)


### PR DESCRIPTION
## Changes Made

This PR adds the standard uppercase `README.md` file to follow GitHub's convention for repository documentation files.

## Issue with Lowercase File

Due to case-sensitivity limitations in Git and the available API tools, the lowercase `readme.md` file might still be present after this PR is merged. This is because Git considers these files to be the same on case-insensitive file systems. 

## Recommended Solution

1. Merge this PR first to add the correctly cased README.md file
2. Use the GitHub web interface to directly delete the lowercase readme.md file in a subsequent operation
3. Alternatively, clone the repo locally to a case-sensitive file system, remove the lowercase file, and push the changes

## Preview

The changes can be previewed at:
https://jane-alesi.github.io/satware.ai/

## Testing

- Verified that the uppercase README.md has been created correctly
- Confirmed that the content matches the original