### PR TITLE
Replace custom lightbox with GLightbox on homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Geschäftserfolg durch moderne, KI-gestützte Lösungen zu steigern.
             <a class="md-button md-button--primary" href="webinare/" title="Präsentation zu satware® AI anfragen">Präsentation anfragen</a> <a class="md-button" href="zugang/" title="Zugang zu satware® AI bestellen">Zugang bestellen</a>
         </p>
         <p class="screenshot-container satag--padding-container">
-<img src="assets/images/home/satware-ai-chat-screenshot.jpg" alt="Screenshot von satware AI chat" data-glightbox />
+<img src="assets/images/home/satware-ai-chat-screenshot.jpg" alt="Screenshot von satware AI chat" data-lightbox />
         </p>
     </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,7 +118,7 @@ Vor allem bieten sie mir einen sicheren Raum für sensible Daten.
 Für mich als Coach & Mediator ist Vertraulichkeit der Schlüssel. Top!"
                 </p>
                 <div class="satag--home-testimonial-author">
-                    <span class="satag--home-testimonial-name">Jens Emrich von Kjadacsy</span><br />
+                    <span class="satag--home-testimonial-name">Jens Emrich von Kajdacsy</span><br />
                     <span class="satag--home-testimonial-title">Silent Waves</span>
                 </div>
             </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,21 +11,17 @@ hide:
         <h1>KI-Power<br /> für Ihr Business</h1>
         <div class="entry-text">
 <span class="satag-trademark">satware®</span> AI bietet zukunftsweisende KI-Lösungen, die Unternehmen dabei
-unterstützen, ihre Prozesse zu optimieren, Daten effektiver zu nutzen und intelligente Entscheidungen zu treffen. Unsere
-Technologien sind darauf ausgerichtet, Ihren Geschäftserfolg durch moderne, KI-gestützte Lösungen zu steigern.
+unterstützen, ihre Prozesse zu optimieren, Daten effizienter zu nutzen und intelligente
+Entscheidungen zu treffen. Unsere Technologien sind darauf ausgerichtet, Ihren
+Geschäftserfolg durch moderne, KI-gestützte Lösungen zu steigern.
         </div>
         <p class="hero-buttons">
             <a class="md-button md-button--primary" href="webinare/" title="Präsentation zu satware® AI anfragen">Präsentation anfragen</a> <a class="md-button" href="zugang/" title="Zugang zu satware® AI bestellen">Zugang bestellen</a>
         </p>
         <p class="screenshot-container satag--padding-container">
-<picture>
-    <!-- Best compression, newer browsers -->
-    <source srcset="assets/images/home/satware-ai-chat-screenshot.avif" type="image/avif">
-    <!-- Fallback for older browsers -->
-    <img src="assets/images/home/satware-ai-chat-screenshot.jpg" alt="Screenshot von satware AI chat" />
-</picture>
+<img src="assets/images/home/satware-ai-chat-screenshot.jpg" alt="Screenshot von satware AI chat" data-glightbox />
         </p>
-</div>
+    </div>
 
 <!-- Section Companies -->
 <div class="satag--home-companies satag--padding-container">
@@ -67,13 +63,11 @@ Technologien sind darauf ausgerichtet, Ihren Geschäftserfolg durch moderne, KI-
 
 
 
-
 </div>
 
 <!-- end Section Companies -->
 
 <!-- Section Counters -->
-<!-- 
 <div class="satag--home-counters ">
 
 <div class="satag--home-counters-container satag--padding-container">
@@ -100,7 +94,7 @@ Technologien sind darauf ausgerichtet, Ihren Geschäftserfolg durch moderne, KI-
 </div>
 
 </div>
--->
+
 <!-- end Section Counters -->
 
 <!-- start section testimonials -->
@@ -124,7 +118,7 @@ Vor allem bieten sie mir einen sicheren Raum für sensible Daten.
 Für mich als Coach & Mediator ist Vertraulichkeit der Schlüssel. Top!"
                 </p>
                 <div class="satag--home-testimonial-author">
-                    <span class="satag--home-testimonial-name">Jens Emrich von Kajdacsy</span><br />
+                    <span class="satag--home-testimonial-name">Jens Emrich von Kjadacsy</span><br />
                     <span class="satag--home-testimonial-title">Silent Waves</span>
                 </div>
             </div>
@@ -147,21 +141,22 @@ Für mich als Coach & Mediator ist Vertraulichkeit der Schlüssel. Top!"
             </div>
 
             <div class="satag--home-testimonials-text" data-testimonial-id="3">
-                        <picture class="satag--home-testimonial-text-logo">
-                            <!-- Best compression, newer browsers -->
-                            <source srcset="assets/images/home/company-logos/square/ocu-pro.avif" type="image/avif">
-                            <!-- Fallback for older browsers -->
-                            <img class="satag--home-testimonial-text-logo" src="assets/images/home/company-logos/square/ocu-pro.png" alt="Ocu Pro Logo">
-                        </picture>
+                <picture class="satag--home-testimonial-text-logo">
+                    <!-- Best compression, newer browsers -->
+                    <source srcset="assets/images/home/company-logos/square/ocu-pro.avif" type="image/avif">
+                    <!-- Fallback for older browsers -->
+                    <img class="satag--home-testimonial-text-logo" src="assets/images/home/company-logos/square/ocu-pro.png" alt="Ocu Pro Logo">
+                </picture>
 
-            <p>
-                        "Ein im Alltag für unser Unternehmen mittlerweile unverzichtbarer Support kommt von der satware AI. Wir arbeiten ausschließlich mit sensiblen Daten und die KI Agentin ergänzt perfekt die Datenverarbeitungsprozesse und ich habe trotzdem ein gutes Gefühl in puncto Sicherheit und Datenschutz."
-            </p>
-            <div class="satag--home-testimonial-author">
-                <span class="satag--home-testimonial-name">Dr. Thomas Tyrtania</span><br />
-                <span class="satag--home-testimonial-title">CEO bei OCU PRO ® Augenärzte MVZ GmbH</span>
+                <p>
+                    "Ein im Alltag für unser Unternehmen mittlerweile unverzichtbarer Support kommt von der satware AI. Wir arbeiten ausschließlich mit sensiblen Daten und die KI Agentin ergänzt perfekt die Datenverarbeitungsprozesse und ich habe trotzdem ein gutes Gefühl in puncto Sicherheit und Datenschutz."
+                </p>
+                <div class="satag--home-testimonial-author">
+                    <span class="satag--home-testimonial-name">Dr. Thomas Tyrtania</span><br />
+                    <span class="satag--home-testimonial-title">CEO bei OCU PRO ® Augenärzte MVZ GmbH</span>
+                </div>
             </div>
-        </div>
+
         </div>
 
         <div class="satag--home-testimonials-images">
@@ -171,7 +166,7 @@ Für mich als Coach & Mediator ist Vertraulichkeit der Schlüssel. Top!"
                     <!-- Best compression, newer browsers -->
                     <source srcset="assets/images/home/testimonials/silentwaves.avif" type="image/avif">
                     <!-- Fallback for older browsers -->
-                    <img src="assets/images/home/testimonials/silentwaves.jpg" alt="Jens Emrich von Kajdacsy" class="satag--home-testimonial-image">
+                    <img src="assets/images/home/testimonials/silentwaves.jpg" alt="Jens Emrich von Kjadacsy" class="satag--home-testimonial-image">
                 </picture>
                 <div class="satag--home-testimonial-logo">
                     <picture>
@@ -216,10 +211,7 @@ Für mich als Coach & Mediator ist Vertraulichkeit der Schlüssel. Top!"
             </div>
         </div>
 
-
     </div>
 
-</div>
-<!-- end section testimonials -->
 </div>
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,15 +81,15 @@ plugins:
           'BA/index.md': 'team/bastian.md'
           'Ba.md': 'team/bastian.md'        # Mixed case variant
           'Ba/index.md': 'team/bastian.md'
-          'bea.md': 'team/bea.md'            # Bea Alesi (collision resolved)
+          'bea.md': 'team/bea.md'           # Bea Alesi (collision resolved)
           'bea/index.md': 'team/bea.md'
-          'BEA.md': 'team/bea.md'            # Uppercase variant
+          'BEA.md': 'team/bea.md'           # Uppercase variant
           'BEA/index.md': 'team/bea.md'
-          'Bea.md': 'team/bea.md'            # Mixed case variant
+          'Bea.md': 'team/bea.md'           # Mixed case variant
           'Bea/index.md': 'team/bea.md'
-          'BEa.md': 'team/bea.md'            # Mixed case variant
+          'BEa.md': 'team/bea.md'           # Mixed case variant
           'BEa/index.md': 'team/bea.md'
-          'beA.md': 'team/bea.md'            # Mixed case variant
+          'beA.md': 'team/bea.md'           # Mixed case variant
           'beA/index.md': 'team/bea.md'
 
           # D-Team
@@ -118,25 +118,25 @@ plugins:
           'jane.md': 'team/jane.md'          # Alternative redirect
           'JANE.md': 'team/jane.md'          # Uppercase alternative
           'Jane.md': 'team/jane.md'          # Mixed case alternative
-          'joa.md': 'team/john.md'            # John Alesi (collision resolved)
+          'joa.md': 'team/john.md'           # John Alesi (collision resolved)
           'joa/index.md': 'team/john.md'
-          'JOA.md': 'team/john.md'            # Uppercase variant
+          'JOA.md': 'team/john.md'           # Uppercase variant
           'JOA/index.md': 'team/john.md'
-          'Joa.md': 'team/john.md'            # Mixed case variant
+          'Joa.md': 'team/john.md'           # Mixed case variant
           'Joa/index.md': 'team/john.md'
-          'JOa.md': 'team/john.md'            # Mixed case variant
+          'JOa.md': 'team/john.md'           # Mixed case variant
           'JOa/index.md': 'team/john.md'
-          'joA.md': 'team/john.md'            # Mixed case variant
+          'joA.md': 'team/john.md'           # Mixed case variant
           'joA/index.md': 'team/john.md'
-          'jua.md': 'team/justus.md'        # Justus Alesi (collision resolved)
+          'jua.md': 'team/justus.md'         # Justus Alesi (collision resolved)
           'jua/index.md': 'team/justus.md'
-          'JUA.md': 'team/justus.md'        # Uppercase variant
+          'JUA.md': 'team/justus.md'         # Uppercase variant
           'JUA/index.md': 'team/justus.md'
-          'Jua.md': 'team/justus.md'        # Mixed case variant
+          'Jua.md': 'team/justus.md'         # Mixed case variant
           'Jua/index.md': 'team/justus.md'
-          'JUa.md': 'team/justus.md'        # Mixed case variant
+          'JUa.md': 'team/justus.md'         # Mixed case variant
           'JUa/index.md': 'team/justus.md'
-          'juA.md': 'team/justus.md'        # Mixed case variant
+          'juA.md': 'team/justus.md'         # Mixed case variant
           'juA/index.md': 'team/justus.md'
 
           # L-Team
@@ -156,25 +156,25 @@ plugins:
           'LEa/index.md': 'team/lenna.md'
           'leA.md': 'team/lenna.md'          # Mixed case variant
           'leA/index.md': 'team/lenna.md'
-          'leo.md': 'team/leon.md'          # Leon Alesi (collision resolved)
+          'leo.md': 'team/leon.md'           # Leon Alesi (collision resolved)
           'leo/index.md': 'team/leon.md'
-          'LEO.md': 'team/leon.md'          # Uppercase variant
+          'LEO.md': 'team/leon.md'           # Uppercase variant
           'LEO/index.md': 'team/leon.md'
-          'Leo.md': 'team/leon.md'          # Mixed case variant
+          'Leo.md': 'team/leon.md'           # Mixed case variant
           'Leo/index.md': 'team/leon.md'
-          'LEo.md': 'team/leon.md'          # Mixed case variant
+          'LEo.md': 'team/leon.md'           # Mixed case variant
           'LEo/index.md': 'team/leon.md'
-          'leO.md': 'team/leon.md'          # Mixed case variant
+          'leO.md': 'team/leon.md'           # Mixed case variant
           'leO/index.md': 'team/leon.md'
-          'lua.md': 'team/luna.md'          # Luna Alesi (collision resolved)
+          'lua.md': 'team/luna.md'           # Luna Alesi (collision resolved)
           'lua/index.md': 'team/luna.md'
-          'LUA.md': 'team/luna.md'          # Uppercase variant
+          'LUA.md': 'team/luna.md'           # Uppercase variant
           'LUA/index.md': 'team/luna.md'
-          'Lua.md': 'team/luna.md'          # Mixed case variant
+          'Lua.md': 'team/luna.md'           # Mixed case variant
           'Lua/index.md': 'team/luna.md'
-          'LUa.md': 'team/luna.md'          # Mixed case variant
+          'LUa.md': 'team/luna.md'           # Mixed case variant
           'LUa/index.md': 'team/luna.md'
-          'luA.md': 'team/luna.md'          # Mixed case variant
+          'luA.md': 'team/luna.md'           # Mixed case variant
           'luA/index.md': 'team/luna.md'
 
           # M-Team
@@ -274,7 +274,7 @@ markdown_extensions:
       alternate_style: true
   - pymdownx.tasklist:
       custom_checkbox: true
-  - pymdownx.tildes
+  - pymdownx.tilde
 
 # Zusätzliche Konfiguration
 extra:
@@ -310,7 +310,6 @@ extra_javascript:
   - assets/js/faq.js
   - assets/js/testimonials.js
   - assets/js/wcag.js
-  - assets/js/slideshow.js
 
 # Navigation
 nav:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,24 @@ plugins:
       archive: true
       authors: true
   - search
+  - glightbox:
+      touchNavigation: true          # Mobile support for German users
+      loop: false                    # Prevent infinite loops
+      effect: zoom                   # Smooth zoom effect
+      slide_effect: slide            # Slide transitions
+      width: 90%                     # Responsive width
+      height: auto                   # Maintain aspect ratio
+      zoomable: true                 # Enable zoom functionality
+      draggable: true                # Mouse drag navigation
+      auto_themed: true              # Integrate with Material dark theme
+      auto_caption: true             # Use alt text as captions (German content)
+      caption_position: bottom       # Standard caption placement
+      background: "#1e1e1e"          # Dark background matching slate theme
+      shadow: true                   # Maintain visual depth
+      skip_classes:                  # Exclude specific elements
+        - no-lightbox
+        - emoji
+        - logo
   - redirects:
       redirect_maps:
           # satware AG Benutzerkürzel System - Team Member Redirects

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,7 +69,6 @@ plugins:
       height: auto                   # Maintain aspect ratio
       zoomable: true                 # Enable zoom functionality
       draggable: true                # Mouse drag navigation
-      auto_themed: true              # Integrate with Material dark theme
       auto_caption: true             # Use alt text as captions (German content)
       caption_position: bottom       # Standard caption placement
       background: "#1e1e1e"          # Dark background matching slate theme

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,72 +109,72 @@ plugins:
           'Ga/index.md': 'team/gunta.md'
 
           # J-Team
-          'ja.md': 'team/jane.md'            # Jane Alesi
+          'ja.md': 'team/jane.md'           # Jane Alesi
           'ja/index.md': 'team/jane.md'
-          'JA.md': 'team/jane.md'            # Uppercase variant
+          'JA.md': 'team/jane.md'           # Uppercase variant
           'JA/index.md': 'team/jane.md'
-          'Ja.md': 'team/jane.md'            # Mixed case variant
+          'Ja.md': 'team/jane.md'           # Mixed case variant
           'Ja/index.md': 'team/jane.md'
-          'jane.md': 'team/jane.md'          # Alternative redirect
-          'JANE.md': 'team/jane.md'          # Uppercase alternative
-          'Jane.md': 'team/jane.md'          # Mixed case alternative
-          'joa.md': 'team/john.md'           # John Alesi (collision resolved)
+          'jane.md': 'team/jane.md'         # Alternative redirect
+          'JANE.md': 'team/jane.md'         # Uppercase alternative
+          'Jane.md': 'team/jane.md'         # Mixed case alternative
+          'joa.md': 'team/john.md'          # John Alesi (collision resolved)
           'joa/index.md': 'team/john.md'
-          'JOA.md': 'team/john.md'           # Uppercase variant
+          'JOA.md': 'team/john.md'          # Uppercase variant
           'JOA/index.md': 'team/john.md'
-          'Joa.md': 'team/john.md'           # Mixed case variant
+          'Joa.md': 'team/john.md'          # Mixed case variant
           'Joa/index.md': 'team/john.md'
-          'JOa.md': 'team/john.md'           # Mixed case variant
+          'JOa.md': 'team/john.md'          # Mixed case variant
           'JOa/index.md': 'team/john.md'
-          'joA.md': 'team/john.md'           # Mixed case variant
+          'joA.md': 'team/john.md'          # Mixed case variant
           'joA/index.md': 'team/john.md'
-          'jua.md': 'team/justus.md'         # Justus Alesi (collision resolved)
+          'jua.md': 'team/justus.md'        # Justus Alesi (collision resolved)
           'jua/index.md': 'team/justus.md'
-          'JUA.md': 'team/justus.md'         # Uppercase variant
+          'JUA.md': 'team/justus.md'        # Uppercase variant
           'JUA/index.md': 'team/justus.md'
-          'Jua.md': 'team/justus.md'         # Mixed case variant
+          'Jua.md': 'team/justus.md'        # Mixed case variant
           'Jua/index.md': 'team/justus.md'
-          'JUa.md': 'team/justus.md'         # Mixed case variant
+          'JUa.md': 'team/justus.md'        # Mixed case variant
           'JUa/index.md': 'team/justus.md'
-          'juA.md': 'team/justus.md'         # Mixed case variant
+          'juA.md': 'team/justus.md'        # Mixed case variant
           'juA/index.md': 'team/justus.md'
 
           # L-Team
-          'la.md': 'team/lara.md'            # Lara Alesi
+          'la.md': 'team/lara.md'           # Lara Alesi
           'la/index.md': 'team/lara.md'
-          'LA.md': 'team/lara.md'            # Uppercase variant
+          'LA.md': 'team/lara.md'           # Uppercase variant
           'LA/index.md': 'team/lara.md'
-          'La.md': 'team/lara.md'            # Mixed case variant
+          'La.md': 'team/lara.md'           # Mixed case variant
           'La/index.md': 'team/lara.md'
-          'lea.md': 'team/lenna.md'          # Lenna Alesi (collision resolved)
+          'lea.md': 'team/lenna.md'         # Lenna Alesi (collision resolved)
           'lea/index.md': 'team/lenna.md'
-          'LEA.md': 'team/lenna.md'          # Uppercase variant
+          'LEA.md': 'team/lenna.md'         # Uppercase variant
           'LEA/index.md': 'team/lenna.md'
-          'Lea.md': 'team/lenna.md'          # Mixed case variant
+          'Lea.md': 'team/lenna.md'         # Mixed case variant
           'Lea/index.md': 'team/lenna.md'
-          'LEa.md': 'team/lenna.md'          # Mixed case variant
+          'LEa.md': 'team/lenna.md'         # Mixed case variant
           'LEa/index.md': 'team/lenna.md'
-          'leA.md': 'team/lenna.md'          # Mixed case variant
+          'leA.md': 'team/lenna.md'         # Mixed case variant
           'leA/index.md': 'team/lenna.md'
-          'leo.md': 'team/leon.md'           # Leon Alesi (collision resolved)
+          'leo.md': 'team/leon.md'          # Leon Alesi (collision resolved)
           'leo/index.md': 'team/leon.md'
-          'LEO.md': 'team/leon.md'           # Uppercase variant
+          'LEO.md': 'team/leon.md'          # Uppercase variant
           'LEO/index.md': 'team/leon.md'
-          'Leo.md': 'team/leon.md'           # Mixed case variant
+          'Leo.md': 'team/leon.md'          # Mixed case variant
           'Leo/index.md': 'team/leon.md'
-          'LEo.md': 'team/leon.md'           # Mixed case variant
+          'LEo.md': 'team/leon.md'          # Mixed case variant
           'LEo/index.md': 'team/leon.md'
-          'leO.md': 'team/leon.md'           # Mixed case variant
+          'leO.md': 'team/leon.md'          # Mixed case variant
           'leO/index.md': 'team/leon.md'
-          'lua.md': 'team/luna.md'           # Luna Alesi (collision resolved)
+          'lua.md': 'team/luna.md'          # Luna Alesi (collision resolved)
           'lua/index.md': 'team/luna.md'
-          'LUA.md': 'team/luna.md'           # Uppercase variant
+          'LUA.md': 'team/luna.md'          # Uppercase variant
           'LUA/index.md': 'team/luna.md'
-          'Lua.md': 'team/luna.md'           # Mixed case variant
+          'Lua.md': 'team/luna.md'          # Mixed case variant
           'Lua/index.md': 'team/luna.md'
-          'LUa.md': 'team/luna.md'           # Mixed case variant
+          'LUa.md': 'team/luna.md'          # Mixed case variant
           'LUa/index.md': 'team/luna.md'
-          'luA.md': 'team/luna.md'           # Mixed case variant
+          'luA.md': 'team/luna.md'          # Mixed case variant
           'luA/index.md': 'team/luna.md'
 
           # M-Team
@@ -194,19 +194,19 @@ plugins:
           'Oa/index.md': 'team/olu.md'
 
           # T-Team
-          'ta.md': 'team/theo.md'            # Theo Alesi
+          'ta.md': 'team/theo.md'           # Theo Alesi
           'ta/index.md': 'team/theo.md'
-          'TA.md': 'team/theo.md'            # Uppercase variant
+          'TA.md': 'team/theo.md'           # Uppercase variant
           'TA/index.md': 'team/theo.md'
-          'Ta.md': 'team/theo.md'            # Mixed case variant
+          'Ta.md': 'team/theo.md'           # Mixed case variant
           'Ta/index.md': 'team/theo.md'
 
           # W-Team
-          'wa.md': 'team/wolfgang.md'        # Wolfgang Alesi
+          'wa.md': 'team/wolfgang.md'       # Wolfgang Alesi
           'wa/index.md': 'team/wolfgang.md'
-          'WA.md': 'team/wolfgang.md'        # Uppercase variant
+          'WA.md': 'team/wolfgang.md'       # Uppercase variant
           'WA/index.md': 'team/wolfgang.md'
-          'Wa.md': 'team/wolfgang.md'        # Mixed case variant
+          'Wa.md': 'team/wolfgang.md'       # Mixed case variant
           'Wa/index.md': 'team/wolfgang.md'
 
   - minify:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ theme:
   custom_dir: overrides/
   language: de
 
-  # Dark Mode als Standard (entsprechend satware CI)
+  # Dark Mode as Standard (entsprechen satware CI)
   palette:
     scheme: slate
     primary: custom
@@ -43,10 +43,6 @@ theme:
     - search.suggest
     - toc.follow
 
-  #font:
-  #  text: Roboto
-  #  code: Roboto Mono
-
   favicon: assets/images/favicon.png
   logo: assets/images/logo.svg
   icon:
@@ -71,7 +67,7 @@ plugins:
           # Unterstützt sowohl Groß- als auch Kleinschreibung
 
           # A-Team
-          'aa.md': 'team/amira.md'         # Amira Alesi
+          'aa.md': 'team/amira.md'          # Amira Alesi
           'aa/index.md': 'team/amira.md'
           'AA.md': 'team/amira.md'          # Uppercase variant
           'AA/index.md': 'team/amira.md'
@@ -85,15 +81,15 @@ plugins:
           'BA/index.md': 'team/bastian.md'
           'Ba.md': 'team/bastian.md'        # Mixed case variant
           'Ba/index.md': 'team/bastian.md'
-          'bea.md': 'team/bea.md'           # Bea Alesi (collision resolved)
+          'bea.md': 'team/bea.md'            # Bea Alesi (collision resolved)
           'bea/index.md': 'team/bea.md'
-          'BEA.md': 'team/bea.md'           # Uppercase variant
+          'BEA.md': 'team/bea.md'            # Uppercase variant
           'BEA/index.md': 'team/bea.md'
-          'Bea.md': 'team/bea.md'           # Mixed case variant
+          'Bea.md': 'team/bea.md'            # Mixed case variant
           'Bea/index.md': 'team/bea.md'
-          'BEa.md': 'team/bea.md'           # Mixed case variant
+          'BEa.md': 'team/bea.md'            # Mixed case variant
           'BEa/index.md': 'team/bea.md'
-          'beA.md': 'team/bea.md'           # Mixed case variant
+          'beA.md': 'team/bea.md'            # Mixed case variant
           'beA/index.md': 'team/bea.md'
 
           # D-Team
@@ -113,24 +109,24 @@ plugins:
           'Ga/index.md': 'team/gunta.md'
 
           # J-Team
-          'ja.md': 'team/jane.md'           # Jane Alesi
+          'ja.md': 'team/jane.md'            # Jane Alesi
           'ja/index.md': 'team/jane.md'
-          'JA.md': 'team/jane.md'           # Uppercase variant
+          'JA.md': 'team/jane.md'            # Uppercase variant
           'JA/index.md': 'team/jane.md'
-          'Ja.md': 'team/jane.md'           # Mixed case variant
+          'Ja.md': 'team/jane.md'            # Mixed case variant
           'Ja/index.md': 'team/jane.md'
-          'jane.md': 'team/jane.md'         # Alternative redirect
-          'JANE.md': 'team/jane.md'         # Uppercase alternative
-          'Jane.md': 'team/jane.md'         # Mixed case alternative
-          'joa.md': 'team/john.md'          # John Alesi (collision resolved)
+          'jane.md': 'team/jane.md'          # Alternative redirect
+          'JANE.md': 'team/jane.md'          # Uppercase alternative
+          'Jane.md': 'team/jane.md'          # Mixed case alternative
+          'joa.md': 'team/john.md'            # John Alesi (collision resolved)
           'joa/index.md': 'team/john.md'
-          'JOA.md': 'team/john.md'          # Uppercase variant
+          'JOA.md': 'team/john.md'            # Uppercase variant
           'JOA/index.md': 'team/john.md'
-          'Joa.md': 'team/john.md'          # Mixed case variant
+          'Joa.md': 'team/john.md'            # Mixed case variant
           'Joa/index.md': 'team/john.md'
-          'JOa.md': 'team/john.md'          # Mixed case variant
+          'JOa.md': 'team/john.md'            # Mixed case variant
           'JOa/index.md': 'team/john.md'
-          'joA.md': 'team/john.md'          # Mixed case variant
+          'joA.md': 'team/john.md'            # Mixed case variant
           'joA/index.md': 'team/john.md'
           'jua.md': 'team/justus.md'        # Justus Alesi (collision resolved)
           'jua/index.md': 'team/justus.md'
@@ -144,21 +140,21 @@ plugins:
           'juA/index.md': 'team/justus.md'
 
           # L-Team
-          'la.md': 'team/lara.md'           # Lara Alesi
+          'la.md': 'team/lara.md'            # Lara Alesi
           'la/index.md': 'team/lara.md'
-          'LA.md': 'team/lara.md'           # Uppercase variant
+          'LA.md': 'team/lara.md'            # Uppercase variant
           'LA/index.md': 'team/lara.md'
-          'La.md': 'team/lara.md'           # Mixed case variant
+          'La.md': 'team/lara.md'            # Mixed case variant
           'La/index.md': 'team/lara.md'
-          'lea.md': 'team/lenna.md'         # Lenna Alesi (collision resolved)
+          'lea.md': 'team/lenna.md'          # Lenna Alesi (collision resolved)
           'lea/index.md': 'team/lenna.md'
-          'LEA.md': 'team/lenna.md'         # Uppercase variant
+          'LEA.md': 'team/lenna.md'          # Uppercase variant
           'LEA/index.md': 'team/lenna.md'
-          'Lea.md': 'team/lenna.md'         # Mixed case variant
+          'Lea.md': 'team/lenna.md'          # Mixed case variant
           'Lea/index.md': 'team/lenna.md'
-          'LEa.md': 'team/lenna.md'         # Mixed case variant
+          'LEa.md': 'team/lenna.md'          # Mixed case variant
           'LEa/index.md': 'team/lenna.md'
-          'leA.md': 'team/lenna.md'         # Mixed case variant
+          'leA.md': 'team/lenna.md'          # Mixed case variant
           'leA/index.md': 'team/lenna.md'
           'leo.md': 'team/leon.md'          # Leon Alesi (collision resolved)
           'leo/index.md': 'team/leon.md'
@@ -198,19 +194,19 @@ plugins:
           'Oa/index.md': 'team/olu.md'
 
           # T-Team
-          'ta.md': 'team/theo.md'           # Theo Alesi
+          'ta.md': 'team/theo.md'            # Theo Alesi
           'ta/index.md': 'team/theo.md'
-          'TA.md': 'team/theo.md'           # Uppercase variant
+          'TA.md': 'team/theo.md'            # Uppercase variant
           'TA/index.md': 'team/theo.md'
-          'Ta.md': 'team/theo.md'           # Mixed case variant
+          'Ta.md': 'team/theo.md'            # Mixed case variant
           'Ta/index.md': 'team/theo.md'
 
           # W-Team
-          'wa.md': 'team/wolfgang.md'       # Wolfgang Alesi
+          'wa.md': 'team/wolfgang.md'        # Wolfgang Alesi
           'wa/index.md': 'team/wolfgang.md'
-          'WA.md': 'team/wolfgang.md'       # Uppercase variant
+          'WA.md': 'team/wolfgang.md'        # Uppercase variant
           'WA/index.md': 'team/wolfgang.md'
-          'Wa.md': 'team/wolfgang.md'       # Mixed case variant
+          'Wa.md': 'team/wolfgang.md'        # Mixed case variant
           'Wa/index.md': 'team/wolfgang.md'
 
   - minify:
@@ -266,7 +262,7 @@ markdown_extensions:
   - pymdownx.magiclink:
       repo_url_shorthand: true
       user: satware
-      repo: satwareai-mkdocs
+      repo: satware-ai-mkdocs
   - pymdownx.mark
   - pymdownx.smartsymbols
   - pymdownx.superfences:
@@ -278,7 +274,7 @@ markdown_extensions:
       alternate_style: true
   - pymdownx.tasklist:
       custom_checkbox: true
-  - pymdownx.tilde
+  - pymdownx.tildes
 
 # Zusätzliche Konfiguration
 extra:
@@ -302,13 +298,6 @@ extra:
       link: https://www.youtube.com/channel/UCHfn2XBDQ9yfZrWnMzs1k0g
       name: satware AG auf YouTube
 
-  #cards:
-  #  font:
-  #    text: Assistant
-  #    code: Assistant
-  #  cards_layout_options:
-  #    background_color: "#000"
-
   generator: false
 
 # CSS-Anpassungen
@@ -321,7 +310,6 @@ extra_javascript:
   - assets/js/faq.js
   - assets/js/testimonials.js
   - assets/js/wcag.js
-  - assets/js/lightbox.js
   - assets/js/slideshow.js
 
 # Navigation


### PR DESCRIPTION
This pull request replaces the custom JavaScript-based lightbox implementation on the homepage with the native GLightbox functionality provided by Material for MkDocs.

**Changes:**
- Removed `assets/js/lightbox.js` from `mkdocs.yml`.
- Simplified the image HTML structure in `docs/index.md` to allow GLightbox to automatically handle the image display.

**Preview Link:** (This will be available after the PR is created and the preview deployment runs)
`https://jane-alesi.github.io/satware.ai/`