### PR TITLE
fix(matomo): Add data-cfasync=false to bypass Cloudflare Rocket Loader

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -27,7 +27,7 @@
 <script src="https://cloud.ccm19.de/app.js?apiKey=a6de2022ab5cc5d4e53927c6ce8dbf1783a551a8668aad1d&amp;domain=6818770b621759a9310961b2" referrerpolicy="origin"></script>
 
 <!-- Matomo -->
-<script type="text/javascript">
+<script type="text/javascript" data-cfasync="false">
     var _paq = window._paq = window._paq || [];
     /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
     _paq.push(["setExcludedQueryParams", ["utm_source","utm_medium","utm_campaign","utm_content","utm_term","fbclid","gclid","_ga","ref","osCsid","uKey"]]);


### PR DESCRIPTION
Cloudflare Rocket Loader modifies script type attributes, which prevents Matomo tracking from working correctly on GitHub Pages. Adding the data-cfasync='false' attribute prevents Rocket Loader from modifying the Matomo tracking script.

This ensures that type='text/javascript' remains unchanged and Matomo can execute properly for analytics tracking.