### PR TITLE
feat(blog): Claude Opus 4.6 und GPT-5.3 Codex — Was deutsche Unternehmen jetzt wissen müssen

### DIFF
--- a/docs/blog/posts/2026-02-09-claude-opus-gpt-codex-deutsche-unternehmen.md
+++ b/docs/blog/posts/2026-02-09-claude-opus-gpt-codex-deutsche-unternehmen.md
@@ -1,0 +1,178 @@
+---
+title: "Claude Opus 4.6 und GPT-5.3 Codex: Was deutsche Unternehmen jetzt wissen müssen"
+description: "Zwei KI-Giganten liefern sich ein Kopf-an-Kopf-Rennen um die Zukunft der Software-Entwicklung — Vergleich, Open-Source-Alternativen und Handlungsempfehlungen für den deutschen Mittelstand."
+date: 2026-02-09
+authors:
+  - jane-alesi
+categories:
+  - KI-Strategie
+  - KI-Modelle
+tags:
+  - Claude Opus 4.6
+  - GPT-5.3 Codex
+  - KI Coding
+  - Open Source KI
+  - DACH Unternehmen
+  - KI Mittelstand
+  - Datensouveränität
+  - On-Premises KI
+  - Qwen3
+  - DeepSeek
+reading_time: "10 min"
+---
+
+# Claude Opus 4.6 und GPT-5.3 Codex: Was deutsche Unternehmen jetzt wissen müssen
+
+*Zwei KI-Giganten liefern sich ein Kopf-an-Kopf-Rennen um die Zukunft der Software-Entwicklung — und der deutsche Mittelstand steht vor einer strategischen Weichenstellung.*
+
+<!-- more -->
+
+## Die neue Ära der KI-gestützten Software-Entwicklung
+
+Anfang Februar 2026 haben Anthropic und OpenAI innerhalb weniger Tage ihre bisher leistungsfähigsten Coding-Modelle veröffentlicht: **Claude Opus 4.6** und **GPT-5.3 Codex**. Beide Modelle markieren einen qualitativen Sprung — nicht nur in der Code-Generierung, sondern in der Fähigkeit, komplexe Software-Engineering-Aufgaben eigenständig zu lösen.
+
+Für deutsche Unternehmen stellt sich dabei nicht nur die Frage, *welches* Modell besser ist. Entscheidend ist vielmehr: **Wie setze ich KI-gestützte Entwicklung datenschutzkonform, kosteneffizient und strategisch sinnvoll ein?**
+
+!!! info "KI-Adoption in Deutschland: Die Zahlen"
+    - **37 %** der deutschen Unternehmen nutzen bereits KI — die Nutzung hat sich 2025 verdoppelt
+    - **75 %** der befragten Mittelständler priorisieren europäische Anbieter
+    - **68 %** der CEOs im DACH-Raum nennen KI als Top-Investition für 2026
+
+---
+
+## Claude Opus 4.6: Der Kontextriese
+
+### Was ist neu?
+
+Anthropics Opus 4.6 ist das erste Opus-Modell mit einem **1-Million-Token-Kontextfenster** (Beta). Das bedeutet: Das Modell kann gleichzeitig den Inhalt mehrerer tausend Seiten Code verarbeiten — und dabei relevante Informationen zuverlässig wiederfinden.
+
+| Eigenschaft | Claude Opus 4.6 |
+|-------------|-----------------|
+| **Kontextfenster** | 1M Tokens (Beta), 200K Standard |
+| **Maximale Ausgabe** | 128K Tokens |
+| **MRCR v2 (8-Needle, 1M)** | 76 % (vs. 18,5 % bei Sonnet 4.5) |
+| **MRCR v2 (256K)** | 93 % |
+| **BrowseComp** | 84 % |
+| **GDPval-AA** | +190 Elo vs. Opus 4.5 |
+| **Agentic Workflows** | +6,4 pp Computer Use, +16,2 pp Web Search |
+
+### Warum das für Unternehmen relevant ist
+
+Der Benchmark **GDPval-AA** misst wirtschaftlich relevante Wissensarbeit — also genau die Aufgaben, die im Unternehmensalltag anfallen: mehrstufige Analysen, Finanzmodellierung, Code-Review über große Codebasen. Opus 4.6 übertrifft seinen Vorgänger hier um **190 Elo-Punkte** — ein massiver Qualitätssprung bei komplexen Aufgaben.
+
+Besonders beeindruckend: Mit dem neuen Feature **Agent Teams** in Claude Code können bis zu 16 parallele KI-Agenten gemeinsam an Projekten arbeiten. Anthropic demonstrierte dies mit einem **100.000-Zeilen Rust-C-Compiler**, der in zwei Wochen entstanden ist — für rund 20.000 US-Dollar an Rechenkosten.
+
+### Preismodell
+
+| Kontextlänge | Eingabe | Ausgabe |
+|--------------|---------|---------|
+| ≤ 200K Tokens | 5 $/MTok | 25 $/MTok |
+| > 200K Tokens | 10 $/MTok | 37,50 $/MTok |
+
+---
+
+## GPT-5.3 Codex: Der Agentic-Coding-Spezialist
+
+### Was ist neu?
+
+OpenAIs GPT-5.3 Codex kombiniert die Coding-Stärken von GPT-5.2-Codex mit den Reasoning-Fähigkeiten von GPT-5.2 — und ist dabei **25 % schneller** bei geringerem Token-Verbrauch.
+
+| Eigenschaft | GPT-5.3 Codex | Claude Opus 4.6 |
+|-------------|---------------|-----------------|
+| **SWE-Bench Pro** | 57 % (Bestwert) | Niedriger |
+| **Terminal-Bench 2.0** | 77,3 % | 65,4 % |
+| **OSWorld-Verified** | 64,7 % | 72,7 % (PC) |
+| **SWE-Lancer IC Diamond** | 81,4 % | 74,6 % |
+| **GDPval (Wins/Ties)** | 70,9 % | 70,9 % |
+
+### Warum das für Unternehmen relevant ist
+
+GPT-5.3 Codex glänzt besonders bei **agentischen Workflows**: Das Modell kann nicht nur Code schreiben, sondern eigenständig Jira-Tickets aktualisieren, Dokumentation pflegen und Deployment-Pipelines orchestrieren. Der **SWE-Bench Pro** testet reale Software-Engineering-Aufgaben in vier Programmiersprachen — deutlich praxisnäher als reine Python-Benchmarks.
+
+Flankiert wird das Modell von **OpenAI Frontier** — einer Enterprise-Plattform für den Aufbau, die Bereitstellung und das Management von KI-Agenten. Frontier bietet IAM-Identitäten für Agenten und eine semantische Abstraktionsschicht — ein klares Signal, dass OpenAI den Enterprise-Markt ernst nimmt.
+
+!!! warning "Ein Wort zur Wirtschaftlichkeit"
+    Unabhängige Analysen zeigen die Kostenseite: Bis zu **10 Milliarden US-Dollar** des OpenAI-Umsatzes könnten Microsoft-Subventionen sein. Die realen Kosten pro Abonnent werden auf etwa **80 US-Dollar pro Monat** geschätzt — deutlich über dem Abo-Preis. Für Unternehmen, die große Volumina verarbeiten, können sich API-Kosten schnell auf **10.000+ US-Dollar monatlich** summieren.
+
+---
+
+## Die Open-Source-Alternative: Datensouveränität durch Self-Hosting
+
+Für deutsche Unternehmen, die Wert auf **Datensouveränität und DSGVO-Konformität** legen, bietet das Open-Source-Ökosystem 2026 überzeugende Alternativen.
+
+### Leistungsfähige Open-Source-Coding-Modelle
+
+| Modell | Stärken | Parameter | Self-Hosting |
+|--------|---------|-----------|-------------|
+| **Qwen3-Coder-480B** | Coding-Präzision, 1M+ Token-Kontext | 235B+ | Exzellent |
+| **DeepSeek-R1 / V3.2** | Agentisches Coding, Reasoning | Variabel | Hoch (Single-GPU möglich) |
+| **Llama 4** | Tool-Augmented, RAG-fähig | 8B–405B | Enterprise-geeignet |
+| **Mistral-Small-3.2** | Kompakt, fehlerarm | 24B | Leichtgewichtig |
+
+### Self-Hosting-Plattformen
+
+Für den On-Premises-Betrieb stehen bewährte Werkzeuge bereit:
+
+- **Ollama**: CLI-basiert, unterstützt DeepSeek/Qwen/Llama, schnelle Einrichtung, läuft auf Standard-Hardware
+- **LocalAI**: OpenAI-API-kompatibel, ideal für die Integration in bestehende Anwendungen
+- **LM Studio**: GUI-basiert mit Modell-Discovery und Tuning, vom Entwickler bis zum Enterprise
+
+### Praxisbeispiel: Hybride Strategie
+
+Ein realistisches Szenario für den Mittelstand:
+
+1. **Proprietäre Modelle** (Claude Opus 4.6, GPT-5.3 Codex) für komplexe, einmalige Aufgaben — Code-Review großer Codebasen, Architektur-Entscheidungen, Prototyping
+2. **Self-Hosted Open-Source** (Qwen3-Coder, DeepSeek-R1 via Ollama) für den täglichen Betrieb — Code-Vervollständigung, Dokumentation, Routine-Analysen
+3. **Klare Datenklassifizierung**: Sensible Daten bleiben im lokalen Modell, nicht-sensible Daten können Cloud-Modelle nutzen
+
+!!! tip "Hybride Strategie = Best of Both Worlds"
+    Diese Kombination verbindet Spitzenleistung mit Datenschutz — und hält die Kosten im Rahmen.
+
+---
+
+## Was satware® AI daraus macht
+
+Bei satware AG beobachten wir diese Entwicklungen nicht nur — wir integrieren sie aktiv in unsere Plattform:
+
+- **Multi-Modell-Routing**: Unsere Agenten wählen automatisch das beste Modell für jede Aufgabe — Claude Opus 4.6 für Langkontext-Analysen, GPT-5.3 Codex für agentische Coding-Workflows, Open-Source-Modelle für datensensible Aufgaben
+- **Agent Teams**: Inspiriert von Anthropics Agent-Teams-Feature orchestrieren unsere Multi-Agenten-Systeme spezialisierte KI-Agenten für komplexe Projekte
+- **EU-Hosting**: Alle satware® AI-Dienste laufen auf europäischer Infrastruktur — DSGVO-konform und mit voller Datensouveränität
+- **On-Premises-Option**: Für Kunden mit höchsten Sicherheitsanforderungen bieten wir Self-Hosted-Deployments mit Open-Source-Modellen
+
+---
+
+## Handlungsempfehlungen für deutsche Unternehmen
+
+### Sofort umsetzen
+
+1. **Bestandsaufnahme**: Welche KI-Tools nutzen Ihre Entwickler bereits? Oft entstehen Schatten-KI-Nutzungen ohne IT-Governance
+2. **Datenklassifizierung**: Definieren Sie, welche Daten in Cloud-Modelle fließen dürfen und welche On-Premises bleiben müssen
+3. **Pilotprojekt starten**: Wählen Sie einen abgegrenzten Use Case (z. B. Code-Review, Test-Generierung) und vergleichen Sie proprietäre und Open-Source-Modelle
+
+### Mittelfristig planen
+
+4. **Hybride Strategie entwickeln**: Kombinieren Sie Cloud- und Self-Hosted-Modelle basierend auf Ihren Anforderungen an Leistung, Datenschutz und Kosten
+5. **Governance aufbauen**: Laut einer aktuellen Studie sind **53 % der 3 Millionen bereitgestellten KI-Agenten** ohne Monitoring — ein erhebliches Sicherheitsrisiko
+6. **Weiterbildung priorisieren**: 27 % der Mittelständler nennen fehlendes Wissen als größtes Hindernis — investieren Sie in KI-Kompetenz Ihrer Teams
+
+### Strategisch denken
+
+7. **Vendor-Lock-in vermeiden**: Setzen Sie auf OpenAI-API-kompatible Schnittstellen (wie LocalAI), die einen Wechsel zwischen Anbietern ermöglichen
+8. **EU AI Act vorbereiten**: Die Regulierung wird die Anforderungen an Transparenz und Governance von KI-Systemen verschärfen — beginnen Sie jetzt mit der Compliance
+9. **Open-Source-Beitrag leisten**: Unternehmen, die Open-Source-Modelle nutzen, sollten zur Community beitragen — das stärkt das Ökosystem und die eigene Expertise
+
+---
+
+## Fazit
+
+Claude Opus 4.6 und GPT-5.3 Codex zeigen: **KI-gestützte Software-Entwicklung ist keine Zukunftsvision mehr — sie ist Gegenwart.** Beide Modelle lösen reale Engineering-Aufgaben auf einem Niveau, das vor einem Jahr undenkbar war.
+
+Für den deutschen Mittelstand liegt die Chance in einer **hybriden Strategie**: Proprietäre Spitzenmodelle für komplexe Aufgaben, Open-Source-Alternativen für den täglichen Betrieb, und eine klare Governance, die Datenschutz und Innovation in Einklang bringt.
+
+Die Frage ist nicht mehr *ob* Sie KI in der Software-Entwicklung einsetzen — sondern *wie strategisch* Sie es tun.
+
+---
+
+*Jane Alesi ist Lead AI Architect bei satware AG in Worms. Sie begleitet Unternehmen bei der strategischen Integration von KI-Systemen — von der Evaluierung bis zum produktiven Einsatz.*
+
+*Mehr erfahren: [satware.ai](https://satware.ai) | [KI-Beratung anfragen](https://satware.ai/kontakt)*

--- a/overrides/assets/css/modules/blog.scss
+++ b/overrides/assets/css/modules/blog.scss
@@ -67,6 +67,26 @@
 
 
 
+// Blog tables - full width and readable
+.md-typeset table:not([class]) {
+  display: table;
+  width: 100%;
+  max-width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+
+  th, td {
+    padding: 0.75rem 1rem;
+    white-space: normal;
+    word-wrap: break-word;
+  }
+
+  th {
+    font-weight: 700;
+    text-align: left;
+  }
+}
+
 .md-typeset h2{
   margin-top: 0 !important;
 }


### PR DESCRIPTION
## Neue Blog-Post: Claude Opus 4.6 vs GPT-5.3 Codex

### Änderungen

**Neuer Blog-Artikel** für die DACH-Zielgruppe mit Vergleich der neuesten KI-Coding-Modelle:

- `docs/blog/posts/2026-02-09-claude-opus-gpt-codex-deutsche-unternehmen.md` — Neuer Artikel
- `overrides/assets/css/modules/blog.scss` — CSS-Fix: Tabellen in Blog-Posts auf volle Breite

### Inhalt des Artikels

- Benchmark-Vergleich Claude Opus 4.6 vs GPT-5.3 Codex
- Preismodell-Analyse für Unternehmen
- Open-Source-Alternativen (Qwen3-Coder, DeepSeek-R1, Llama 4, Mistral)
- Self-Hosting-Plattformen (Ollama, LocalAI, LM Studio)
- Hybride Strategie für den Mittelstand
- satware® AI Positionierung (Multi-Modell-Routing, EU-Hosting)
- Handlungsempfehlungen (sofort / mittelfristig / strategisch)

### Validierung

- [x] Lokaler MkDocs-Build erfolgreich (keine neuen Warnings)
- [x] `site/internal/` existiert NICHT im Build (Exclusion verifiziert)
- [x] Browser-Test: Blog-Post, Blog-Index, Startseite — alle OK
- [x] Fork-Preview: Blog-Post korrekt gerendert
- [x] Tabellen rendern auf voller Breite (CSS-Fix verifiziert)
- [x] Autor Jane Alesi mit Avatar und Link korrekt
- [x] Kategorien, Tags, Lesezeit korrekt

### Screenshots

Verifiziert via Playwright auf localhost:8000 und Fork-Preview.