### PR TITLE
style(blog): improve footnote styling for dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,12 @@
 /site
 /_site
 /docs/assets/css/custom.css
+/overrides/assets/css/custom.css
 /package-lock.json
 # Add readme.md to ensure case sensitivity is enforced
 # This commit includes an attempt to delete readme.md
 /docs/assets/css/custom.css.map
+/overrides/assets/css/custom.css.map
 
 # Ruby/Bundler (orphaned files - this is a Python/MkDocs project)
 Gemfile.lock

--- a/overrides/assets/css/modules/blog.scss
+++ b/overrides/assets/css/modules/blog.scss
@@ -148,3 +148,71 @@
 
 
 }
+
+// Footnote styling - improved readability for dark theme
+// Inline footnote references (superscript numbers in body text)
+.md-typeset sup {
+  font-size: 75%;
+
+  .footnote-ref {
+    font-weight: 600;
+    text-decoration: none;
+    padding: 0.1em 0.2em;
+    border-radius: 0.2em;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.1);
+      text-decoration: none;
+    }
+  }
+}
+
+// Footnote section at the bottom of articles
+.md-typeset div.footnote {
+  margin-top: 2rem;
+  font-size: 0.85rem;
+  line-height: 1.6;
+
+  // Separator line above footnotes
+  hr {
+    border-color: rgba(255, 255, 255, 0.12);
+    margin-bottom: 1rem;
+  }
+
+  // Footnote ordered list
+  ol {
+    padding-left: 1.5rem;
+    margin: 0;
+
+    li {
+      margin-bottom: 0.5rem;
+      padding-left: 0.25rem;
+
+      p {
+        margin: 0;
+        display: inline;
+      }
+    }
+  }
+
+  // Back-reference links (↩) — inline, compact
+  .footnote-backref {
+    display: inline-block;
+    margin-left: 0.2em;
+    font-size: 0.9em;
+    text-decoration: none;
+    opacity: 0.6;
+    transition: opacity 0.2s ease;
+
+    &:hover {
+      opacity: 1;
+      text-decoration: none;
+    }
+
+    // Reduce spacing when multiple ↩ links are present
+    + .footnote-backref {
+      margin-left: 0.1em;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes footnote CSS styling issues in blog posts on the dark theme.

### Problems Fixed
- **Inline footnote references** (`sup` / `.footnote-ref`): Increased font size to 75% with bold weight and added subtle hover background for better clickability
- **Footnote section spacing**: Reduced excessive vertical gaps between footnote entries (`div.footnote ol li`) with 0.5rem margin-bottom
- **Back-reference links** (`↩`): Made `inline-block` with compact spacing, reduced opacity (0.6 → 1.0 on hover) to declutter multiple back-links (e.g., footnote [^1] referenced 6 times)
- **Footnote paragraphs**: Set to `display: inline` to prevent block-level spacing issues causing newline effects
- **Dark theme readability**: Proper contrast for separator lines and text at 0.85rem

### Also
- Added compiled CSS artifacts (`overrides/assets/css/custom.css`) to `.gitignore`

### Tested On
- Blog post: *Die Schweizer KI-Revolution* (8 footnotes, footnote [^1] referenced 6x)
- localhost:8000 with dark theme (slate)